### PR TITLE
Add custom ripple effect

### DIFF
--- a/app/src/main/res/drawable/background_item_pokemon.xml
+++ b/app/src/main/res/drawable/background_item_pokemon.xml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
-<item>
-    <shape>
-        <solid android:color="@color/backgroundLight"/>
-        <corners android:radius="15dp"/>
-    </shape>
-</item>
-</layer-list>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
+
+    <item>
+        <shape>
+            <solid android:color="@color/backgroundLight" />
+            <corners android:radius="15dp" />
+        </shape>
+    </item>
+
+    <item android:id="@android:id/mask">
+        <shape>
+            <!-- Color doesn't matter -->
+            <solid android:color="@android:color/white" />
+            <corners android:radius="15dp" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/layout/item_generation.xml
+++ b/app/src/main/res/layout/item_generation.xml
@@ -11,8 +11,6 @@
     android:clipToPadding="false"
     android:elevation="8dp"
     android:focusable="true"
-    android:foreground="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
     android:padding="8dp">
 
     <TextView

--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -10,9 +10,8 @@
     android:clickable="true"
     android:clipToPadding="false"
     android:focusable="true"
-    android:foreground="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
-    android:padding="8dp">
+    android:padding="8dp"
+    tools:backgroundTint="@color/lightTeal">
 
     <TextView
         android:id="@+id/textViewName"

--- a/app/src/main/res/layout/item_pokemon.xml
+++ b/app/src/main/res/layout/item_pokemon.xml
@@ -10,9 +10,8 @@
     android:clickable="true"
     android:clipToPadding="false"
     android:focusable="true"
-    android:foreground="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
-    android:padding="8dp">
+    android:padding="8dp"
+    tools:backgroundTint="@color/lightTeal">
 
     <TextView
         android:id="@+id/textViewName"


### PR DESCRIPTION
Adding a custom ripple effect to list item backgrounds, so when a list item is tapped the ripple does not run out of the rounded edges of the list item background. 

Before:
![old1](https://user-images.githubusercontent.com/3823933/81006889-8948d100-8e50-11ea-98af-eb7553be69c6.gif)
![old2](https://user-images.githubusercontent.com/3823933/81006894-8a79fe00-8e50-11ea-8bf1-139f8ce969db.gif)
![old3](https://user-images.githubusercontent.com/3823933/81006896-8b129480-8e50-11ea-88fa-3b7460c21542.gif)


After:
![new1](https://user-images.githubusercontent.com/3823933/81006874-851cb380-8e50-11ea-936d-fa51329f2fc7.gif)
![new2](https://user-images.githubusercontent.com/3823933/81006885-877f0d80-8e50-11ea-9af8-7c2c267d3ddc.gif)
![new3](https://user-images.githubusercontent.com/3823933/81006888-88b03a80-8e50-11ea-9686-74baae27fdcd.gif)