### PR TITLE
ViewPager2 Migration

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,6 +3,7 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="..\:/AndroidStudioProjects/Kotlin-Pokedex/app/src/main/res/layout/fragment_dashboard.xml" value="0.16894630192502533" />
         <entry key="app/src/main/res/layout/fragment_dashboard.xml" value="0.1381340579710145" />
         <entry key="app/src/main/res/layout/fragment_home.xml" value="0.14719202898550723" />
         <entry key="app/src/main/res/layout/item_pokemon.xml" value="0.1265625" />
@@ -10,7 +11,7 @@
     </option>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/dev/marcosfarias/pokedex/ui/dashboard/ViewPagerAdapter.kt
+++ b/app/src/main/java/dev/marcosfarias/pokedex/ui/dashboard/ViewPagerAdapter.kt
@@ -3,7 +3,8 @@ package dev.marcosfarias.pokedex.ui.dashboard
 import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.lifecycle.Lifecycle
+import androidx.viewpager2.adapter.FragmentStateAdapter
 import dev.marcosfarias.pokedex.R
 import dev.marcosfarias.pokedex.ui.dashboard.about.AboutFragment
 import dev.marcosfarias.pokedex.ui.dashboard.evolution.EvolutionFragment
@@ -13,8 +14,17 @@ import dev.marcosfarias.pokedex.ui.dashboard.stats.StatsFragment
 class ViewPagerAdapter(
     supportFragmentManager: FragmentManager,
     context: Context,
+    lifecycle: Lifecycle,
     private val pokemonId: String
-) : FragmentStatePagerAdapter(supportFragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+) : FragmentStateAdapter(supportFragmentManager, lifecycle) {
+
+    override fun getItemCount(): Int {
+        return pages.size
+    }
+
+    override fun createFragment(position: Int): Fragment {
+        return pages[position].ctor()
+    }
 
     data class Page(val title: String, val ctor: () -> Fragment)
 
@@ -38,15 +48,7 @@ class ViewPagerAdapter(
         )
     )
 
-    override fun getItem(position: Int): Fragment {
-        return pages[position].ctor()
-    }
-
-    override fun getCount(): Int {
-        return pages.size
-    }
-
-    override fun getPageTitle(position: Int): CharSequence? {
+    fun getPageTitle(position: Int): CharSequence {
         return pages[position].title
     }
 }

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -175,7 +175,7 @@
         android:fillViewport="true"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <androidx.viewpager.widget.ViewPager
+        <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
### Removal of Deprecated `FragmentStatePagerAdapter` Fixes #45 
- In order to replace this, had to migrate to ViewPager2
- ViewPager2 is the newer version of ViewPager and should be used instead of old ViewPager